### PR TITLE
[codex] Remove Komiku API from sidebar

### DIFF
--- a/src/constants/sidebar.tsx
+++ b/src/constants/sidebar.tsx
@@ -5,7 +5,6 @@ import { FaBlog } from "react-icons/fa";
 import { CiChat1 } from "react-icons/ci";
 import { BiSolidDashboard } from "react-icons/bi";
 import { AiFillProject } from "react-icons/ai";
-import { LuFileJson } from "react-icons/lu";
 
 const ICON_SIZE: number = 24;
 
@@ -25,11 +24,6 @@ export const SIDEBAR_ITEMS = [
     icon: <AiFillProject size={ICON_SIZE} />,
     pathname: "/projects",
     label: "Project",
-  },
-  {
-    icon: <LuFileJson size={ICON_SIZE} />,
-    pathname: "/komiku-api-docs",
-    label: "Komiku API",
   },
   {
     icon: <BiSolidDashboard size={ICON_SIZE} />,


### PR DESCRIPTION
## Summary
- Remove the Komiku API docs entry from the sidebar navigation.
- Keep the docs page accessible directly at `/komiku-api-docs` and from the README link.

## Validation
- `npm run lint` passed with existing unrelated `<img>` warnings.
